### PR TITLE
Implement translation service with MyMemory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,96 @@
-# summafy
-テキスト要約API（Summarize + Simplify）
+# Summafy
+
+テキスト翻訳マイクロサービス。MyMemory Translation API を利用した REST API。
+
+## クイックスタート
+
+### Docker（推奨）
+
+```bash
+docker compose up --build
+```
+
+http://localhost:8000 でサーバーが起動します。
+
+### ローカル開発
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install .[dev]
+uvicorn src.main:app --reload
+```
+
+## API エンドポイント
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/health` | ヘルスチェック |
+| POST | `/translate` | テキスト翻訳 |
+| GET | `/translate/languages` | サポート言語一覧 |
+
+### POST /translate
+
+```bash
+curl -X POST http://localhost:8000/translate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello, world!", "target_lang": "ja"}'
+```
+
+レスポンス:
+
+```json
+{
+  "translated_text": "こんにちは、世界！",
+  "source_lang": "auto",
+  "target_lang": "ja"
+}
+```
+
+`source_lang` を省略すると自動検出されます。明示的に指定することもできます:
+
+```bash
+curl -X POST http://localhost:8000/translate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello", "source_lang": "en", "target_lang": "fr"}'
+```
+
+### GET /translate/languages
+
+```bash
+curl http://localhost:8000/translate/languages
+```
+
+## 環境変数
+
+| 変数 | デフォルト | 説明 |
+|------|-----------|------|
+| `SUMMAFY_MYMEMORY_API_URL` | `https://api.mymemory.translated.net/get` | 翻訳 API の URL |
+| `SUMMAFY_TRANSLATION_TIMEOUT` | `10.0` | API タイムアウト（秒） |
+| `SUMMAFY_LOG_LEVEL` | `info` | ログレベル |
+
+## 開発
+
+```bash
+# リント
+ruff check .
+ruff format --check .
+
+# 型チェック
+mypy src/
+
+# テスト
+pytest -v
+
+# フォーマット
+ruff format .
+```
+
+## 技術スタック
+
+- Python 3.12+
+- FastAPI / Uvicorn
+- MyMemory Translation API
+- Docker / Docker Compose
+- Ruff（リンター/フォーマッター）+ mypy（型チェック）
+- GitHub Actions CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi>=0.115,<1",
     "uvicorn[standard]>=0.34,<1",
     "httpx>=0.28,<1",
+    "pydantic-settings>=2.7,<3",
 ]
 
 [project.optional-dependencies]

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,16 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    mymemory_api_url: str = "https://api.mymemory.translated.net/get"
+    translation_timeout: float = 10.0
+    log_level: str = "info"
+
+    model_config = {"env_prefix": "SUMMAFY_"}
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,10 @@
+class TranslationError(Exception):
+    """Base exception for translation errors."""
+
+
+class ExternalAPIError(TranslationError):
+    """External translation API returned an error."""
+
+
+class TranslationTimeoutError(TranslationError):
+    """External translation API timed out."""

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,25 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
+from src.exceptions import TranslationError, TranslationTimeoutError
 from src.routers import translate
 
 app = FastAPI(title="Summafy", version="0.1.0")
 app.include_router(translate.router)
+
+
+@app.exception_handler(TranslationTimeoutError)
+async def timeout_handler(
+    _request: Request, exc: TranslationTimeoutError
+) -> JSONResponse:
+    return JSONResponse(status_code=504, content={"detail": str(exc)})
+
+
+@app.exception_handler(TranslationError)
+async def translation_error_handler(
+    _request: Request, exc: TranslationError
+) -> JSONResponse:
+    return JSONResponse(status_code=502, content={"detail": str(exc)})
 
 
 @app.get("/health")

--- a/src/routers/translate.py
+++ b/src/routers/translate.py
@@ -1,15 +1,52 @@
 from fastapi import APIRouter
 
-from src.schemas import TranslateRequest, TranslateResponse
+from src.schemas import (
+    LanguageInfo,
+    LanguagesResponse,
+    TranslateRequest,
+    TranslateResponse,
+)
+from src.services.translation import translate
 
 router = APIRouter(prefix="/translate", tags=["translate"])
+
+SUPPORTED_LANGUAGES: list[LanguageInfo] = [
+    LanguageInfo(code="en", name="English"),
+    LanguageInfo(code="ja", name="Japanese"),
+    LanguageInfo(code="zh", name="Chinese"),
+    LanguageInfo(code="ko", name="Korean"),
+    LanguageInfo(code="fr", name="French"),
+    LanguageInfo(code="de", name="German"),
+    LanguageInfo(code="es", name="Spanish"),
+    LanguageInfo(code="pt", name="Portuguese"),
+    LanguageInfo(code="it", name="Italian"),
+    LanguageInfo(code="ru", name="Russian"),
+    LanguageInfo(code="ar", name="Arabic"),
+    LanguageInfo(code="hi", name="Hindi"),
+    LanguageInfo(code="th", name="Thai"),
+    LanguageInfo(code="vi", name="Vietnamese"),
+    LanguageInfo(code="id", name="Indonesian"),
+    LanguageInfo(code="nl", name="Dutch"),
+    LanguageInfo(code="pl", name="Polish"),
+    LanguageInfo(code="sv", name="Swedish"),
+    LanguageInfo(code="tr", name="Turkish"),
+]
 
 
 @router.post("", response_model=TranslateResponse)
 async def translate_text(req: TranslateRequest) -> TranslateResponse:
-    # TODO: implement actual translation logic
-    return TranslateResponse(
-        translated_text=req.text,
-        source_lang=req.source_lang or "auto",
+    result = await translate(
+        text=req.text,
         target_lang=req.target_lang,
+        source_lang=req.source_lang,
     )
+    return TranslateResponse(
+        translated_text=result.translated_text,
+        source_lang=result.source_lang,
+        target_lang=result.target_lang,
+    )
+
+
+@router.get("/languages", response_model=LanguagesResponse)
+async def list_languages() -> LanguagesResponse:
+    return LanguagesResponse(languages=SUPPORTED_LANGUAGES)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -7,10 +7,21 @@ class TranslateRequest(BaseModel):
         default=None,
         description="Source language code (e.g. 'en'). Auto-detect if omitted.",
     )
-    target_lang: str = Field(..., description="Target language code (e.g. 'ja')")
+    target_lang: str = Field(
+        ..., description="Target language code (e.g. 'ja')"
+    )
 
 
 class TranslateResponse(BaseModel):
     translated_text: str
     source_lang: str
     target_lang: str
+
+
+class LanguageInfo(BaseModel):
+    code: str
+    name: str
+
+
+class LanguagesResponse(BaseModel):
+    languages: list[LanguageInfo]

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -7,9 +7,7 @@ class TranslateRequest(BaseModel):
         default=None,
         description="Source language code (e.g. 'en'). Auto-detect if omitted.",
     )
-    target_lang: str = Field(
-        ..., description="Target language code (e.g. 'ja')"
-    )
+    target_lang: str = Field(..., description="Target language code (e.g. 'ja')")
 
 
 class TranslateResponse(BaseModel):

--- a/src/services/translation.py
+++ b/src/services/translation.py
@@ -34,17 +34,13 @@ async def translate(
             )
             resp.raise_for_status()
     except httpx.TimeoutException as e:
-        raise TranslationTimeoutError(
-            "Translation API timed out"
-        ) from e
+        raise TranslationTimeoutError("Translation API timed out") from e
     except httpx.HTTPStatusError as e:
         raise ExternalAPIError(
             f"Translation API returned {e.response.status_code}"
         ) from e
     except httpx.HTTPError as e:
-        raise ExternalAPIError(
-            f"Translation API request failed: {e}"
-        ) from e
+        raise ExternalAPIError(f"Translation API request failed: {e}") from e
 
     data: dict[str, object] = resp.json()
     response_data = data["responseData"]

--- a/src/services/translation.py
+++ b/src/services/translation.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+import httpx
+
+from src.config import Settings, get_settings
+
+
+@dataclass(frozen=True)
+class TranslationResult:
+    translated_text: str
+    source_lang: str
+    target_lang: str
+
+
+async def translate(
+    text: str,
+    target_lang: str,
+    source_lang: str | None = None,
+    settings: Settings | None = None,
+) -> TranslationResult:
+    """Translate text using MyMemory API."""
+    cfg = settings or get_settings()
+    src = source_lang or "autodetect"
+    langpair = f"{src}|{target_lang}"
+
+    async with httpx.AsyncClient(timeout=cfg.translation_timeout) as client:
+        resp = await client.get(
+            cfg.mymemory_api_url,
+            params={"q": text, "langpair": langpair},
+        )
+        resp.raise_for_status()
+
+    data = resp.json()
+    response_data: dict[str, str] = data["responseData"]
+    translated = response_data["translatedText"]
+
+    return TranslationResult(
+        translated_text=translated,
+        source_lang=source_lang or "auto",
+        target_lang=target_lang,
+    )

--- a/src/services/translation.py
+++ b/src/services/translation.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import httpx
 
 from src.config import Settings, get_settings
+from src.exceptions import ExternalAPIError, TranslationTimeoutError
 
 
 @dataclass(frozen=True)
@@ -23,16 +24,33 @@ async def translate(
     src = source_lang or "autodetect"
     langpair = f"{src}|{target_lang}"
 
-    async with httpx.AsyncClient(timeout=cfg.translation_timeout) as client:
-        resp = await client.get(
-            cfg.mymemory_api_url,
-            params={"q": text, "langpair": langpair},
-        )
-        resp.raise_for_status()
+    try:
+        async with httpx.AsyncClient(
+            timeout=cfg.translation_timeout,
+        ) as client:
+            resp = await client.get(
+                cfg.mymemory_api_url,
+                params={"q": text, "langpair": langpair},
+            )
+            resp.raise_for_status()
+    except httpx.TimeoutException as e:
+        raise TranslationTimeoutError(
+            "Translation API timed out"
+        ) from e
+    except httpx.HTTPStatusError as e:
+        raise ExternalAPIError(
+            f"Translation API returned {e.response.status_code}"
+        ) from e
+    except httpx.HTTPError as e:
+        raise ExternalAPIError(
+            f"Translation API request failed: {e}"
+        ) from e
 
-    data = resp.json()
-    response_data: dict[str, str] = data["responseData"]
-    translated = response_data["translatedText"]
+    data: dict[str, object] = resp.json()
+    response_data = data["responseData"]
+    if not isinstance(response_data, dict):
+        raise ExternalAPIError("Unexpected API response format")
+    translated = str(response_data["translatedText"])
 
     return TranslationResult(
         translated_text=translated,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.translation import TranslationResult
+
+
+def _make_mock(
+    return_value: TranslationResult | None = None,
+    side_effect: Exception | None = None,
+) -> AsyncMock:
+    mock = AsyncMock()
+    if side_effect:
+        mock.side_effect = side_effect
+    else:
+        mock.return_value = return_value or TranslationResult(
+            translated_text="こんにちは",
+            source_lang="auto",
+            target_lang="ja",
+        )
+    return mock
+
+
+@pytest.fixture()
+def mock_translate_success() -> Iterator[AsyncMock]:
+    with patch(
+        "src.routers.translate.translate", new_callable=AsyncMock
+    ) as m:
+        m.return_value = TranslationResult(
+            translated_text="こんにちは",
+            source_lang="auto",
+            target_lang="ja",
+        )
+        yield m
+
+
+@pytest.fixture()
+def mock_translate_timeout() -> Iterator[AsyncMock]:
+    from src.exceptions import TranslationTimeoutError
+
+    with patch(
+        "src.routers.translate.translate", new_callable=AsyncMock
+    ) as m:
+        m.side_effect = TranslationTimeoutError("Translation API timed out")
+        yield m
+
+
+@pytest.fixture()
+def mock_translate_error() -> Iterator[AsyncMock]:
+    from src.exceptions import ExternalAPIError
+
+    with patch(
+        "src.routers.translate.translate", new_callable=AsyncMock
+    ) as m:
+        m.side_effect = ExternalAPIError("Translation API returned 500")
+        yield m

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,7 @@ def _make_mock(
 
 @pytest.fixture()
 def mock_translate_success() -> Iterator[AsyncMock]:
-    with patch(
-        "src.routers.translate.translate", new_callable=AsyncMock
-    ) as m:
+    with patch("src.routers.translate.translate", new_callable=AsyncMock) as m:
         m.return_value = TranslationResult(
             translated_text="こんにちは",
             source_lang="auto",
@@ -39,9 +37,7 @@ def mock_translate_success() -> Iterator[AsyncMock]:
 def mock_translate_timeout() -> Iterator[AsyncMock]:
     from src.exceptions import TranslationTimeoutError
 
-    with patch(
-        "src.routers.translate.translate", new_callable=AsyncMock
-    ) as m:
+    with patch("src.routers.translate.translate", new_callable=AsyncMock) as m:
         m.side_effect = TranslationTimeoutError("Translation API timed out")
         yield m
 
@@ -50,8 +46,6 @@ def mock_translate_timeout() -> Iterator[AsyncMock]:
 def mock_translate_error() -> Iterator[AsyncMock]:
     from src.exceptions import ExternalAPIError
 
-    with patch(
-        "src.routers.translate.translate", new_callable=AsyncMock
-    ) as m:
+    with patch("src.routers.translate.translate", new_callable=AsyncMock) as m:
         m.side_effect = ExternalAPIError("Translation API returned 500")
         yield m

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+client = TestClient(app)
+
+
+def test_languages_returns_list() -> None:
+    resp = client.get("/translate/languages")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "languages" in data
+    assert len(data["languages"]) > 0
+    lang = data["languages"][0]
+    assert "code" in lang
+    assert "name" in lang
+
+
+def test_languages_contains_common() -> None:
+    resp = client.get("/translate/languages")
+    codes = {lang["code"] for lang in resp.json()["languages"]}
+    assert {"en", "ja", "es", "fr", "zh"}.issubset(codes)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -44,9 +44,7 @@ def test_translate_missing_text() -> None:
 
 
 def test_translate_empty_text() -> None:
-    resp = client.post(
-        "/translate", json={"text": "", "target_lang": "ja"}
-    )
+    resp = client.post("/translate", json={"text": "", "target_lang": "ja"})
     assert resp.status_code == 422
 
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 from fastapi.testclient import TestClient
 
 from src.main import app
@@ -11,18 +13,56 @@ def test_health() -> None:
     assert resp.json() == {"status": "ok"}
 
 
-def test_translate() -> None:
+def test_translate_success(mock_translate_success: AsyncMock) -> None:
     resp = client.post(
         "/translate",
         json={"text": "hello", "target_lang": "ja"},
     )
     assert resp.status_code == 200
     data = resp.json()
+    assert data["translated_text"] == "こんにちは"
     assert data["target_lang"] == "ja"
     assert data["source_lang"] == "auto"
-    assert data["translated_text"] == "hello"
+
+
+def test_translate_with_source_lang(
+    mock_translate_success: AsyncMock,
+) -> None:
+    resp = client.post(
+        "/translate",
+        json={"text": "hello", "source_lang": "en", "target_lang": "ja"},
+    )
+    assert resp.status_code == 200
+    mock_translate_success.assert_called_once_with(
+        text="hello", target_lang="ja", source_lang="en"
+    )
 
 
 def test_translate_missing_text() -> None:
     resp = client.post("/translate", json={"target_lang": "ja"})
     assert resp.status_code == 422
+
+
+def test_translate_empty_text() -> None:
+    resp = client.post(
+        "/translate", json={"text": "", "target_lang": "ja"}
+    )
+    assert resp.status_code == 422
+
+
+def test_translate_timeout(mock_translate_timeout: AsyncMock) -> None:
+    resp = client.post(
+        "/translate",
+        json={"text": "hello", "target_lang": "ja"},
+    )
+    assert resp.status_code == 504
+    assert "timed out" in resp.json()["detail"]
+
+
+def test_translate_api_error(mock_translate_error: AsyncMock) -> None:
+    resp = client.post(
+        "/translate",
+        json={"text": "hello", "target_lang": "ja"},
+    )
+    assert resp.status_code == 502
+    assert "500" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- MyMemory Translation API を利用した翻訳機能の完全実装
- pydantic-settings による環境変数ベースの設定管理
- カスタム例外によるエラーハンドリング（502/504）
- `GET /translate/languages` エンドポイント追加（19言語）
- モック化されたテスト9件（外部API非依存）
- README にAPI仕様・使い方を記載

## Commits (6)
1. `Add application settings with pydantic-settings` - 設定モジュール
2. `Implement translation service layer with MyMemory API` - 翻訳サービス層
3. `Add error handling with custom exceptions` - エラーハンドリング
4. `Wire translation service into router and add /languages endpoint` - ルーター実装
5. `Update tests with mocked API and error scenarios` - テスト更新
6. `Update README with API docs and usage instructions` - README

## Test plan
- [x] `ruff check .` / `ruff format --check .` パス
- [x] `mypy src/ tests/` パス
- [x] `pytest -v` 全9テストパス
- [x] CI が GitHub Actions 上で正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)